### PR TITLE
Fixed errors for IQFeed v 5.2.4.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # pyiqfeed 
-Reads data from IQFeed (http://www.iqfeed.net)
+
+Reads data from IQFeed (http://www.iqfeed.net).
 
 Contains classes that can read market data from DTN's IQFeed service. You need
 a subscription to IQFeed or this won't work. This library is usually kept up
@@ -25,9 +26,8 @@ file you must define 3 variables:
  dtn_password="Your_IQFEED_PASSWORD"
  </code></pre>
 
-Install the
 This exercises many different parts of the library. The best documentation for
-the library is just reading the file conn.py.
+the library is just reading the file conn.py. Requires python 3.5 
 
 It works for me in live trading. A diligent effort will be made to squash any
 bugs reported to me. Bug reports which do not include a short easy to use python

--- a/pyiqfeed/conn.py
+++ b/pyiqfeed/conn.py
@@ -534,7 +534,8 @@ class QuoteConn(FeedConn):
                           "Calendar Year High Date", "Calendar Year Low Date",
                           "Year End Close", "Maturity Date", "Coupon Rate",
                           "Expiration Date",
-                          "Strike Price", "NAICS", "Exchange Root"]
+                          "Strike Price", "NAICS", "Exchange Root",
+                          "Option Premium Multiplier", "Option Multiple Deliverable"]
 
     fundamental_type = [('Symbol', 'S128'),
                         ('PE', 'f8'),
@@ -574,7 +575,9 @@ class QuoteConn(FeedConn):
                         ('Coupon Rate', 'f8'), ('Expiration Date', 'M8[D]'),
                         ('Strike Price', 'f8'),
                         ('NAICS', 'u8'),
-                        ('Exchange Root', 'S128')]
+                        ('Exchange Root', 'S128'),
+                        ('Option Premium Multiplier', 'f8'),
+                        ('Option Multiple Deliverable', 'u8') ]
 
     # noinspection PyPep8
     quote_msg_map = {'Symbol': ('Symbol', 'S128', lambda x: x),
@@ -843,6 +846,9 @@ class QuoteConn(FeedConn):
         msg['Strike Price'] = read_float64(fields[53])
         msg['NAICS'] = read_uint8(fields[54])
         msg['Exchange Root'] = fields[55]
+        msg['Option Premium Multiplier'] = read_float64(fields[56])
+        msg['Option Multiple Deliverable'] = read_uint8(fields[57])
+
         for listener in self._listeners:
             listener.process_fundamentals(msg)
 


### PR DESCRIPTION
Looks like iQFeed added some new fields in version 5.2.4.0 called Option Premium Multiplier and Option Multiple Deliverable to the Level 1 Fundamental data that was missing and thus causing various and immediate errors.   Scroll to the bottom of the new iQFeed docs to see the description of these new fields (requires iqfeed developer login):  http://www.iqfeed.net/dev/api/docs/Level1FundamentalMessage.cfm

This branch contains code that fixes the errors by adding the new fields "Option Premium Multiplier" and "Option Multiple Deliverable" to all of the data structures in conn.py where Level 1 Fundamental fields are being set and parsed and indexed in the QuoteConn class, ie fundamental_type, fundamental_fields, and the process_fundamentals function. Doing this fixed the errors the library was having upon immediate start.  Library now loads and succeeds at test cases as expected.  

Also minor change, added note that python 3.5 is required in the README. 
