### PR TITLE
Revert "Update conn.py"

### DIFF
--- a/pyiqfeed/conn.py
+++ b/pyiqfeed/conn.py
@@ -107,7 +107,7 @@ def read_hhmmss(field: str) -> int:
         hour = int(field[0:2])
         minute = int(field[3:5])
         second = int(field[6:8])
-        msecs_since_midnight = 1000 * ((3600*hour) + (60*minute) + second)
+        msecs_since_midnight = 1000000 * ((3600*hour) + (60*minute) + second)
         return msecs_since_midnight
     else:
         return 0
@@ -119,7 +119,7 @@ def read_hhmmssmil(field: str) -> int:
         minute = int(field[3:5])
         second = int(field[6:8])
         msecs = int(field[9:])
-        msecs_since_midnight = (1000 *
+        msecs_since_midnight = (1000000 *
                                 ((3600*hour) + (60*minute) + second)) + msecs
         return msecs_since_midnight
     else:


### PR DESCRIPTION
Reverts akapur/pyiqfeed#4
ms in the code stands for microseconds not milliseconds. Changing the multiplier to 1000 at these two spots but not changing it elsewhere breaks a bunch of stuff.

We could rework the whole library to work with milliseconds instead but this pull request did not do that. In any event that's not desirable because by using microseconds we can use a the smallest resolution across multiple market data vendors/exchanges.
