### PR TITLE
Refactored NewsConn as discussed

### DIFF
--- a/example.py
+++ b/example.py
@@ -262,7 +262,7 @@ if __name__ == "__main__":
     #
     counter=0
     for headline in headlines:
-        story = news_conn.request_news_story(id = headline['id'] )
+        story = news_conn.request_news_story(story_id= headline['id'] )
         print("\nNEWS STORY CONTENT:\n", story, "\n")
         counter += 1
         if counter == 3: break

--- a/example.py
+++ b/example.py
@@ -2,10 +2,10 @@
 
 if __name__ == "__main__":
     from pyiqfeed.service import FeedService
-    from pyiqfeed.listeners import VerboseIQFeedListener, VerboseQuoteListener, VerboseAdminListener, VerboseDerivListener
-    from pyiqfeed.listeners import SilentIQFeedListener, SilentQuoteListener, SilentAdminListener, SilentDerivListener
+    from pyiqfeed.listeners import VerboseIQFeedListener, VerboseQuoteListener, VerboseAdminListener, VerboseBarListener
+    from pyiqfeed.listeners import SilentIQFeedListener, SilentQuoteListener, SilentAdminListener, SilentBarListener
     from pyiqfeed.passwords import dtn_login, dtn_password, dtn_product_id
-    from pyiqfeed.conn import AdminConn, QuoteConn, HistoryConn, LookupConn, TableConn,  NewsConn, DerivConn
+    from pyiqfeed.conn import AdminConn, QuoteConn, HistoryConn, LookupConn, TableConn,  NewsConn, BarConn
     from pprint import pprint
     import datetime
     import time
@@ -192,12 +192,12 @@ if __name__ == "__main__":
 
 
     #
-    # Let's test the DerivConn class:
+    # Let's test the BarConn class:
     #
-    deriv_conn = DerivConn(name="RunningInIDE")
-    deriv_listener = VerboseDerivListener("DerivListener")
-    deriv_conn.add_listener(deriv_listener)
-    deriv_conn.start_runner()
+    bar_conn = BarConn(name="RunningInIDE")
+    bar_listener = VerboseBarListener("BarListener")
+    bar_conn.add_listener(bar_listener)
+    bar_conn.start_runner()
 
     # if( len(f_opt['c']) > 10 ):
     #     f_opt['c'] = f_opt['c'][0:10]
@@ -207,15 +207,15 @@ if __name__ == "__main__":
 
     for deriv in derivatives:
         # request bars in invervals of every 60 seconds:
-        deriv_conn.request_interval_bar_watch(  symbol=deriv ,
+        bar_conn.request_interval_bar_watch(  symbol=deriv ,
                                                 interval=60,
                                                 bgn_prd=start_tm,
                                                 max_days_data=50,
                                                 interval_type='s' )
 
     time.sleep(3)
-    deriv_conn.unwatch_all()
-    deriv_conn.stop_runner()
+    bar_conn.unwatch_all()
+    bar_conn.stop_runner()
     time.sleep(1)
 
     #

--- a/pyiqfeed/__init__.py
+++ b/pyiqfeed/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ['conn', 'service', 'listeners']
+__all__ = ['conn', 'service', 'listeners', 'exceptions']

--- a/pyiqfeed/listeners.py
+++ b/pyiqfeed/listeners.py
@@ -84,7 +84,7 @@ class SilentAdminListener(SilentIQFeedListener):
         pass
 
 
-class SilentDerivListener(SilentIQFeedListener):
+class SilentBarListener(SilentIQFeedListener):
 
     def __init__(self, name: str):
         super().__init__(name)
@@ -211,7 +211,7 @@ class VerboseAdminListener(VerboseIQFeedListener):
 
 
 # noinspection PyMethodMayBeStatic
-class VerboseDerivListener(VerboseIQFeedListener):
+class VerboseBarListener(VerboseIQFeedListener):
 
     def __init__(self, name: str):
         super().__init__(name)

--- a/pyiqfeed/listeners.py
+++ b/pyiqfeed/listeners.py
@@ -218,10 +218,12 @@ class VerboseBarListener(VerboseIQFeedListener):
 
     def process_bars(self, bar_data: dict) -> None:
         print("%s: Process Bars" % self._name)
-        #print("\n",bar_data,"\n")
-        print("\n")
-        pprint(bar_data)
-        print("\n")
+
+        print( "\n", bar_data[0].dtype.names , "\n", bar_data, "\n" )
+
+        #print("\n")
+        #pprint(bar_data)
+        #print("\n")
 
     def process_invalid_symbol(self, bad_symbol: str) -> None:
         print("%s: Invalid Symbol: %s" % (self._name, bad_symbol))


### PR DESCRIPTION
Refactored NewsConn to request comma delimited text (csv) instead of xml and added a request type to each news api function. 

Did some bigger news text performance/benchmark comparison speed testing.  Majority of results and information is in this thread:  https://github.com/akapur/pyiqfeed/issues/9#issuecomment-247560706

Also reintroduced mkt_tm bug fix (line 455) with slightly better logic (returning time.struct_time((0,0,0,0,0,0,0,0,0)) now instead of empty string) this issue (exception) keeps happening intermittently so this fixes it. 
