### PR TITLE
- Fixed 'assert us >= 0' for int32 overflowed timestamps (in windows)

### DIFF
--- a/pyiqfeed/field_readers.py
+++ b/pyiqfeed/field_readers.py
@@ -259,7 +259,7 @@ def str_or_blank(val) -> str:
 def us_since_midnight_to_time(
         us_dt: Union[int, np.datetime64]) -> datetime.time:
     """Convert us since midnight to datetime.time with rounding."""
-    us = us_dt.astype('int')
+    us = us_dt.astype('int64')
     assert us >= 0
     assert us <= 86400000000
     microsecond = us % 1000000


### PR DESCRIPTION
Faced with a strange bug when tried to launch script under windows environment. From time to time timestamps lead to int32 overflow and as the result of assertion fail.