### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy
+pypiwin32


### PR DESCRIPTION
`pypiwin32` is required when performing a clean install e.g. a new virtualenv, else:

```
File "C:\Users\peter\pyiqfeed\pyiqfeed\service.py", line 137, in launch
ShellExecute = __import__('win32api').ShellExecute
ModuleNotFoundError: No module named 'win32api'
```

Cleverly, the module is named differently (`win32api`) than the required package (`pypiwin32`).