### PR TITLE
Store Popen object

### DIFF
--- a/pyiqfeed/service.py
+++ b/pyiqfeed/service.py
@@ -112,6 +112,8 @@ class FeedService:
                              depth_port,
                              deriv_port)
 
+        self.iqconnect_process = None
+
     def launch(self,
                timeout: int=20,
                check_conn: bool=True,
@@ -149,12 +151,14 @@ class FeedService:
                 iqfeed_call = prefix_str + base_iqfeed_call
 
                 logging.info("Running %s" % iqfeed_call)
-                subprocess.Popen(iqfeed_call,
-                                 shell=True,
-                                 stdin=subprocess.DEVNULL,
-                                 stdout=subprocess.DEVNULL,
-                                 stderr=subprocess.DEVNULL,
-                                 preexec_fn=os.setpgrp)
+                self.iqconnect_process = subprocess.Popen(
+                    iqfeed_call,
+                    shell=True,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    preexec_fn=os.setpgrp)
+
             if check_conn:
                 start_time = time.time()
                 while not _is_iqfeed_running(iqfeed_host=self.iqfeed_host,


### PR DESCRIPTION
Sometimes more control over running iqconnect.exe process is needed. For example if the same IQFeed account is used on another machine (which luckily, because several developers may share the same account to save $) iqconnect.exe shows error message about it, but does not exit unless user clicks OK. In this case I need to be able to kill the process to and start it again. There may be other scenarios when I need to communicate to the running iqconnect.exe process or check if it actually running.