### PR TITLE
Update conn.py

### DIFF
--- a/pyiqfeed/conn.py
+++ b/pyiqfeed/conn.py
@@ -2966,15 +2966,8 @@ class LookupConn(FeedConn):
         assert month_codes is not None or near_months is not None
 
         if month_codes is not None:
-            valid_month_codes = ()
-            if opt_type == 'p':
-                valid_month_codes = LookupConn.put_month_letters
-            elif opt_type == 'c':
-                valid_month_codes = LookupConn.call_month_letters
-            elif opt_type == 'cp' or opt_type == 'pc':
-                valid_month_codes = (
-                    LookupConn.call_month_letters +
-                    LookupConn.put_month_letters)
+            valid_month_codes = LookupConn.futures_month_letters 
+
             # noinspection PyTypeChecker
             for month_code in month_codes:
                 assert month_code in valid_month_codes


### PR DESCRIPTION
amended the <request_futures_option_chain> function to reference the FUTURES monthly letter map instead of the equity map
raised issue " Futures Valid month code assert references equity letter map https://github.com/akapur/pyiqfeed/issues/58 "

